### PR TITLE
Updated Cassandra to 1.0.6

### DIFF
--- a/recipes/cassandra-ec2.properties
+++ b/recipes/cassandra-ec2.properties
@@ -38,5 +38,5 @@ whirr.credential=${env:AWS_SECRET_ACCESS_KEY}
 # whirr.public-key-file=${whirr.private-key-file}.pub
 
 # Expert: specify the version of Cassandra to install.
-#whirr.cassandra.version.major=0.7
-#whirr.cassandra.tarball.url=http://www.apache.org/dist/cassandra/0.7.0/apache-cassandra-0.7.0-bin.tar.gz
+#whirr.cassandra.version.major=1.0.6
+#whirr.cassandra.tarball.url=http://www.apache.org/dist/cassandra/1.0.6/apache-cassandra-1.0.6-bin.tar.gz

--- a/services/cassandra/pom.xml
+++ b/services/cassandra/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-all</artifactId>
-      <version>0.7.0</version>
+      <version>1.0.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cassandra.deps</groupId>

--- a/services/cassandra/src/main/java/org/apache/whirr/service/cassandra/CassandraClusterActionHandler.java
+++ b/services/cassandra/src/main/java/org/apache/whirr/service/cassandra/CassandraClusterActionHandler.java
@@ -40,7 +40,7 @@ public class CassandraClusterActionHandler extends ClusterActionHandlerSupport {
 
   public static final String CASSANDRA_ROLE = "cassandra";
   public static final int CLIENT_PORT = 9160;
-  public static final int JMX_PORT = 8080;
+  public static final int JMX_PORT = 7199;
 
   public static final String BIN_TARBALL = "whirr.cassandra.tarball.url";
   public static final String MAJOR_VERSION = "whirr.cassandra.version.major";

--- a/services/cassandra/src/main/resources/functions/configure_cassandra.sh
+++ b/services/cassandra/src/main/resources/functions/configure_cassandra.sh
@@ -52,6 +52,7 @@ function configure_cassandra() {
   
     sed -i -e "s|listen_address: localhost|listen_address: $PRIVATE_IP|" $config_file
     sed -i -e "s|rpc_address: localhost|rpc_address: 0.0.0.0|" $config_file
+    sed -i -e "s|cluster_name: 'Test Cluster'|cluster_name: 'Whirr'|" $config_file
   fi
 }
 

--- a/services/cassandra/src/main/resources/functions/install_cassandra.sh
+++ b/services/cassandra/src/main/resources/functions/install_cassandra.sh
@@ -16,9 +16,9 @@
 #
 function install_cassandra() {
 
-  C_MAJOR_VERSION=${1:-0.7}
-  C_TAR_URL=${2:-http://archive.apache.org/dist/cassandra/0.7.5/apache-cassandra-0.7.5-bin.tar.gz}
-  
+  C_MAJOR_VERSION=${1:-1.0}
+  C_TAR_URL=${2:-http://archive.apache.org/dist/cassandra/1.0.6/apache-cassandra-1.0.6-bin.tar.gz}
+ 
   c_tar_file=`basename $C_TAR_URL`
   c_tar_dir=`echo $c_tar_file | awk -F '-bin' '{print $1}'`
   


### PR DESCRIPTION
- Updated the url to the Cassandra tarball.
- Changed the JMX port to 7199, which has changed since 0.8 from 8080.
- Changed the clustername directive in cassandra.yaml

Passes 'mvn test' and also successfully spawns a 1.0.6 cluster.
