### PR TITLE
hadoop 1.0.4 has been moved to archive, change the url for hadoop default property

### DIFF
--- a/services/hadoop/src/main/resources/whirr-hadoop-default.properties
+++ b/services/hadoop/src/main/resources/whirr-hadoop-default.properties
@@ -17,7 +17,7 @@
 #
 
 whirr.hadoop.version=1.0.4
-whirr.hadoop.tarball.url=http://apache.osuosl.org/hadoop/common/hadoop-${whirr.hadoop.version}/hadoop-${whirr.hadoop.version}.tar.gz
+whirr.hadoop.tarball.url=http://archive.apache.org/dist/hadoop/core/hadoop-${whirr.hadoop.version}/hadoop-${whirr.hadoop.version}.tar.gz
 
 # Hadoop defaults. The first part of the key is removed by whirr.
 


### PR DESCRIPTION
hadoop 1.0.4 has been moved to archive, change the default url to the correct one, otherwise, the deployment without override the hadoop tarball url will fail.
